### PR TITLE
Add Windows setup instructions and requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,26 @@
-diff --git a/README.md b/README.md
-index 97943f54cffc39f1e194f9d5d072364156ff3eaa..c89f03092d776fda14fccd2f4360e7c4475a85c8 100644
---- a/README.md
-+++ b/README.md
-@@ -1 +1,29 @@
--# Dust
-+# Dust Audio Visualizer
-+
-+This repository contains a small real-time audio visualizer written in Python. It captures audio from the default system output using the `soundcard` library and displays the frequency spectrum in a Pygame window.
-+Install the dependencies using the `requirements.txt` file. On Windows you can
-+set up a virtual environment and install them like so:
-+
-+```bat
-+python -m venv venv
-+venv\Scripts\activate
-+pip install -r requirements.txt
-+```
-+
-+The packages listed are:
-+
-+```
-+soundcard
-+numpy
-+pygame
-+```
-+
-+## Usage
-+
-+Run the visualizer with:
-+
-+```
-+python visualizer.py
-+```
-+
-+Close the window or press `Ctrl+C` to exit.
+# Dust Audio Visualizer
+
+This repository contains a small real-time audio visualizer written in Python. It captures audio from the default system output using the `soundcard` library and displays the frequency spectrum in a Pygame window.
+
+## Setup (Windows)
+
+1. Ensure Python 3.x is installed.
+2. Create and activate a virtual environment:
+   ```bat
+   python -m venv venv
+   venv\Scripts\activate
+   ```
+3. Install the dependencies:
+   ```bat
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+Run the visualizer with:
+
+```bash
+python visualizer.py
+```
+
+Close the window or press `Ctrl+C` to exit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+pygame
+soundcard


### PR DESCRIPTION
## Summary
- fix README so it's no longer a diff
- document how to create a virtual environment and install dependencies on Windows
- list project dependencies in a new `requirements.txt` file

## Testing
- `python -m py_compile visualizer.py`


------
https://chatgpt.com/codex/tasks/task_e_6857fd7bc2c88331aee59dfe4b2065a8