### PR TITLE
Use loopback to capture speaker audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dust Audio Visualizer
 
-This repository contains a small real-time audio visualizer written in Python. It captures audio directly from the system's default **speaker output** (loopback) using the `soundcard` library and displays the frequency spectrum in a Pygame window. No physical microphone is required.
+This repository contains a small real-time audio visualizer written in Python. It captures audio using the `pyaudio` library and displays the frequency spectrum in a Pygame window. On Windows it records from the default speaker output using WASAPI loopback so you can visualize music or other playback. On other platforms the default input device is used.
 
 ## Setup (Windows)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 pygame
-soundcard
+pyaudio


### PR DESCRIPTION
## Summary
- modify visualizer to open a WASAPI loopback stream on Windows
- update README to note capturing speaker output

## Testing
- `python -m py_compile visualizer.py`


------
https://chatgpt.com/codex/tasks/task_e_685802f5b6108331a98854de50725c8a